### PR TITLE
Set ONVIF to default and clean up required fields 

### DIFF
--- a/src/components/camera/configure-form.tsx
+++ b/src/components/camera/configure-form.tsx
@@ -40,12 +40,6 @@ export const CameraDeviceConfigureForm = ({
     }
   }, [gatewayId]);
 
-  useEffect(() => {
-    if (!metadata.type) {
-      handleChange("type", "ONVIF");
-    }
-  }, [metadata.type]);
-
   const gatewayDevices = data?.results ?? [];
   const gateway = gatewayDevices.find((device) => device.id === gatewayId);
 
@@ -53,12 +47,8 @@ export const CameraDeviceConfigureForm = ({
     <PluginComponent>
       <div className="space-y-4">
         <div>
-          <Label className="mb-2">
-            Type
-            <span className="text-red-500">*</span>
-          </Label>
+          <Label className="mb-2">Type</Label>
           <Select
-            defaultValue={"ONVIF"}
             value={metadata.type}
             onValueChange={(value) => handleChange("type", value)}
           >

--- a/src/components/camera/configure-form.tsx
+++ b/src/components/camera/configure-form.tsx
@@ -40,6 +40,12 @@ export const CameraDeviceConfigureForm = ({
     }
   }, [gatewayId]);
 
+  useEffect(() => {
+    if (!metadata.type) {
+      handleChange("type", "ONVIF");
+    }
+  }, []);
+
   const gatewayDevices = data?.results ?? [];
   const gateway = gatewayDevices.find((device) => device.id === gatewayId);
 
@@ -52,7 +58,8 @@ export const CameraDeviceConfigureForm = ({
             <span className="text-red-500">*</span>
           </Label>
           <Select
-            value={metadata.type || ""}
+            defaultValue={"ONVIF"}
+            value={metadata.type}
             onValueChange={(value) => handleChange("type", value)}
           >
             <SelectTrigger className="w-full">
@@ -67,7 +74,6 @@ export const CameraDeviceConfigureForm = ({
         <div>
           <Label className="mb-2">
             Gateway Device
-            <span className="text-red-500">*</span>
           </Label>
           <Select
             value={gatewayId}
@@ -114,7 +120,6 @@ export const CameraDeviceConfigureForm = ({
         <div>
           <Label className="mb-2">
             Endpoint Address
-            <span className="text-red-500">*</span>
           </Label>
           <Input
             type="text"
@@ -127,7 +132,6 @@ export const CameraDeviceConfigureForm = ({
         <div>
           <Label className="mb-2">
             Username
-            <span className="text-red-500">*</span>
           </Label>
           <Input
             placeholder="Camera username"
@@ -140,7 +144,6 @@ export const CameraDeviceConfigureForm = ({
         <div>
           <Label className="mb-2">
             Password
-            <span className="text-red-500">*</span>
           </Label>
           <div className="relative">
             <Input
@@ -172,7 +175,6 @@ export const CameraDeviceConfigureForm = ({
         <div>
           <Label className="mb-2">
             Stream ID
-            <span className="text-red-500">*</span>
           </Label>
           <Input
             placeholder="Camera stream ID"

--- a/src/components/camera/configure-form.tsx
+++ b/src/components/camera/configure-form.tsx
@@ -44,7 +44,7 @@ export const CameraDeviceConfigureForm = ({
     if (!metadata.type) {
       handleChange("type", "ONVIF");
     }
-  }, []);
+  }, [metadata.type]);
 
   const gatewayDevices = data?.results ?? [];
   const gateway = gatewayDevices.find((device) => device.id === gatewayId);
@@ -72,9 +72,7 @@ export const CameraDeviceConfigureForm = ({
         </div>
 
         <div>
-          <Label className="mb-2">
-            Gateway Device
-          </Label>
+          <Label className="mb-2">Gateway Device</Label>
           <Select
             value={gatewayId}
             onValueChange={(value) => handleChange("gateway", value)}
@@ -118,9 +116,7 @@ export const CameraDeviceConfigureForm = ({
         </div>
 
         <div>
-          <Label className="mb-2">
-            Endpoint Address
-          </Label>
+          <Label className="mb-2">Endpoint Address</Label>
           <Input
             type="text"
             placeholder="Camera's endpoint address (e.g., 192.168.1.100)"
@@ -130,9 +126,7 @@ export const CameraDeviceConfigureForm = ({
         </div>
 
         <div>
-          <Label className="mb-2">
-            Username
-          </Label>
+          <Label className="mb-2">Username</Label>
           <Input
             placeholder="Camera username"
             autoComplete="off"
@@ -142,9 +136,7 @@ export const CameraDeviceConfigureForm = ({
         </div>
 
         <div>
-          <Label className="mb-2">
-            Password
-          </Label>
+          <Label className="mb-2">Password</Label>
           <div className="relative">
             <Input
               type={showPassword ? "text" : "password"}
@@ -173,9 +165,7 @@ export const CameraDeviceConfigureForm = ({
         </div>
 
         <div>
-          <Label className="mb-2">
-            Stream ID
-          </Label>
+          <Label className="mb-2">Stream ID</Label>
           <Input
             placeholder="Camera stream ID"
             autoComplete="off"


### PR DESCRIPTION
Initialize camera type to "ONVIF" if not specified and clean up required fields in the CameraDeviceConfigureForm for improved user experience.