### PR TITLE
fix: Hide camera controls inside the stream in mobile view

### DIFF
--- a/src/components/camera/encounter-overview.tsx
+++ b/src/components/camera/encounter-overview.tsx
@@ -128,13 +128,17 @@ export const CameraEncounterOverview = ({ encounter }: Props) => {
               <CameraFeedProvider device={camera}>
                 <div className="relative aspect-video bg-gray-950 group rounded-xl overflow-hidden shadow-lg">
                   <CameraFeedPlayer />
-                  <CameraFeedControls
-                    inlineView
-                    onRelativeMoved={() => setIsAwayFromPreset(true)}
-                  />
+                  <div className="hidden sm:block">
+                    <CameraFeedControls
+                      inlineView
+                      onRelativeMoved={() => setIsAwayFromPreset(true)}
+                    />
+                  </div>
                 </div>
                 <div className="mt-2 sm:hidden">
-                  <CameraFeedControls />
+                  <CameraFeedControls 
+                    onRelativeMoved={() => setIsAwayFromPreset(true)}
+                  />
                 </div>
               </CameraFeedProvider>
             </TabsContent>

--- a/src/components/camera/show-page-card.tsx
+++ b/src/components/camera/show-page-card.tsx
@@ -89,7 +89,9 @@ const CameraStream = ({ device }: { device: CameraDevice }) => {
     <CameraFeedProvider device={device}>
       <div className="relative aspect-video bg-gray-950 group rounded-xl overflow-hidden shadow-lg">
         <CameraFeedPlayer />
-        <CameraFeedControls inlineView />
+        <div className="hidden sm:block">
+          <CameraFeedControls inlineView />
+        </div>
       </div>
       <div className="mt-2 sm:hidden">
         <CameraFeedControls />


### PR DESCRIPTION
## Proposed Changes

- Fixes [55](https://github.com/ohcnetwork/care_teleicu_devices_fe/issues/55) 
- Hide camera controls inside the stream on mobile view using correct tailwind classes.

## Screenshots
![image](https://github.com/user-attachments/assets/cffb8ba0-2bae-44bc-a061-0f2d00987ff6)
