### PR TITLE
Enhance encounter overview to conditionally enable query based on current location availability

### DIFF
--- a/src/components/camera/encounter-overview.tsx
+++ b/src/components/camera/encounter-overview.tsx
@@ -33,6 +33,7 @@ export const CameraEncounterOverview = ({ encounter }: Props) => {
         encounterId: encounter.id,
       },
     }),
+    enabled: !!encounter.current_location?.id,
   });
 
   const { data: positionPresets, isFetching: isFetchingPresets } = useQuery({


### PR DESCRIPTION
Fix: #74 

Change made, the API call will only be made when there's a location assigned to the encounter.

**Before** 
<img width="1485" height="588" alt="image" src="https://github.com/user-attachments/assets/7de19dbf-64a2-44da-92bf-eaf260f1f276" />

**After**
<img width="1485" height="588" alt="image" src="https://github.com/user-attachments/assets/c6fa9f42-6166-4934-a5e0-8f438d6a7482" />

